### PR TITLE
Restore working directory

### DIFF
--- a/udica/policy.py
+++ b/udica/policy.py
@@ -196,3 +196,5 @@ def load_policy(opts):
             print('\nPlease load these modules using: \n# semodule -i ' + opts['ContainerName'] + '.cil ' + TEMPLATES_STORE + "/{" + templates + '}')
         else:
             print('\nPlease load these modules using: \n# semodule -i ' + opts['ContainerName'] + '.cil ' + TEMPLATES_STORE + "/" + templates + '')
+
+        chdir(PWD)


### PR DESCRIPTION
In load_policy(), when the '-l' option is not set, working directory is
not restored back after setting it to TEMPLATES_STORE. Fix this by
calling chdir().