### PR TITLE
Support port ranges

### DIFF
--- a/tests/semanage.py
+++ b/tests/semanage.py
@@ -38,7 +38,10 @@ ports_local = [
 semanage_port_list = Mock(return_value=(0, ports))
 semanage_port_list_local = Mock(return_value=(0, ports_local))
 semanage_port_get_con = Mock(side_effect=lambda x: x[0])
+semanage_port_get_proto = Mock(return_value="tcp")
+semanage_port_get_proto_str = Mock(side_effect=lambda x: x)
 semanage_port_get_low = Mock(side_effect=lambda x: x[1])
+semanage_port_get_high = Mock(side_effect=lambda x: x[1])
 
 fcontexts = [
     ('/var/spool(/.*)?', 'system_u:object_r:var_spool_t:s0'),


### PR DESCRIPTION
Resolves: #16

Previously, udica crashed when it tried to generate allow rule for some
port which is inside some range. This commit fixing the issue.

e.g: podman run -p 8612 fedora bash | udica my_testcon
Traceback (most recent call last):
File "/usr/bin/udica", line 11, in
load_entry_point('udica==0.1.4', 'console_scripts', 'udica')()
File "/usr/lib/python3.7/site-packages/udica/main.py", line 107, in main
create_policy(opts, container_caps, container_mounts, container_ports)
File "/usr/lib/python3.7/site-packages/udica/policy.py", line 118, in create_policy
policy.write(' (allow process ' + list_ports(item['hostPort']) + ' ( ' + perms.socket[item['protocol']] + ' ( name_bind ))) \n')
TypeError: can only concatenate str (not "NoneType") to str

With this fix, udica will choose right port label also based on
checking the corresponding protocol.