### PR TITLE
Add allow rules for container_runtime_t to base_container.cil

### DIFF
--- a/udica/templates/base_container.cil
+++ b/udica/templates/base_container.cil
@@ -5,4 +5,5 @@
 (typeattributeset container_domain (process ))
 (allow process proc_type (file (getattr open read)))
 (allow process cpu_online_t (file (getattr open read)))
+(allow container_runtime_t process (key (create link read search setattr view write)))
 )


### PR DESCRIPTION
Podman version 1.2.0 requires new allow rules.

Fixes:
type=AVC msg=audit(1556617434.540:447): avc:  denied  { create } for  pid=4692 comm="runc:[2:INIT]" scontext=unconfined_u:system_r:container_runtime_t:s0 tcontext=system_u:system_r:my_container.process:s0:c157,c366 tclass=key permissive=1
type=AVC msg=audit(1556617434.541:448): avc:  denied  { search } for  pid=4692 comm="runc:[2:INIT]" scontext=unconfined_u:system_r:container_runtime_t:s0 tcontext=system_u:system_r:my_container.process:s0:c157,c366 tclass=key permissive=1
type=AVC msg=audit(1556617434.541:449): avc:  denied  { view } for  pid=4692 comm="runc:[2:INIT]" scontext=unconfined_u:system_r:container_runtime_t:s0 tcontext=system_u:system_r:my_container.process:s0:c157,c366 tclass=key permissive=1
type=AVC msg=audit(1556617434.541:450): avc:  denied  { setattr } for  pid=4692 comm="runc:[2:INIT]" scontext=unconfined_u:system_r:container_runtime_t:s0 tcontext=system_u:system_r:my_container.process:s0:c157,c366 tclass=key permissive=1