### PR TITLE
 Add an option for running tests with real modules

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -119,3 +119,9 @@ class TestMain(unittest.TestCase):
             self.assertMultiLineEqual(policy, exp_policy)
 
         os.unlink('my_container.cil')
+
+if __name__ == "__main__":
+    if 'selinux_enabled' in sys.argv:
+        SELINUX_ENABLED = True
+        sys.argv.remove('selinux_enabled')
+    unittest.main()


### PR DESCRIPTION
To simplify udica testing on Fedora, add an option that allows running the tests with real system packages (selinux and semanage). This change does not affect Travis CI (this option is turned off by default).