### PR TITLE
Get SELinux context of mountpoint from xattr

### DIFF
--- a/tests/selinux.py
+++ b/tests/selinux.py
@@ -18,4 +18,15 @@ from unittest.mock import Mock
 SELABEL_CTX_FILE = None
 
 selabel_open = Mock()
-selabel_lookup = Mock(return_value=(0, "system_u:object_r:var_spool_t:s0"))
+
+def selabel_lookup(selabel,directory,rc):
+    if directory == '/tmp/test':
+        return (0, None)
+    else:
+        return (0, "system_u:object_r:var_spool_t:s0")
+
+def getfilecon(directory):
+    if directory == '/tmp/test':
+        return (0, "system_u:object_r:user_tmp_t:s0")
+    else:
+        return (0, "system_u:object_r:var_spool_t:s0")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -79,6 +79,12 @@ class TestMain(unittest.TestCase):
                     '{base_container.cil,net_container.cil,home_container.cil}',
                     'test_basic.ansible.podman.yml')
 
+    def test_nocontext_podman(self):
+        """podman run -v /tmp/test:/tmp/test:rw fedora"""
+        args = ['udica', '-j', 'test_nocontext.podman.json', 'my_container']
+        self.helper(args, 'test_nocontext.podman.cil',
+                    'base_container.cil')
+
     def helper(self, args, policy_file=None, templates=None, variables_file=None):
         """Run udica with args, check output and used templates.
 
@@ -94,6 +100,9 @@ class TestMain(unittest.TestCase):
         udica.policy.TEMPLATES_STORE = "../udica/templates"
         # FIXME: the policy module is using global variable which must be reset to []
         udica.policy.templates_to_load = []
+
+        # Create /tmp/test directory for proper testing objects without SELinux context specified
+        os.makedirs("/tmp/test", exist_ok=True)
 
         # Remove current directory from sys.path so that the proper selinux and semanage modules are
         # loaded (instead of the mock ones in this directory).
@@ -167,6 +176,9 @@ class TestMain(unittest.TestCase):
             list_templates = templates.strip('{,}').split(',')
             for template in list_templates:
                 os.unlink(template)
+
+        # Delete /tmp/test directory for proper testing objects without SELinux context specified
+        os.rmdir("/tmp/test")
 
 if __name__ == "__main__":
     if 'selinux_enabled' in sys.argv:

--- a/tests/test_nocontext.podman.cil
+++ b/tests/test_nocontext.podman.cil
@@ -1,0 +1,8 @@
+(block my_container
+    (blockinherit container)
+    (allow process process ( capability ( chown dac_override fsetid fowner mknod net_raw setgid setuid setfcap setpcap net_bind_service sys_chroot kill audit_write ))) 
+
+    (allow process user_tmp_t ( dir ( open read getattr lock search ioctl add_name remove_name write ))) 
+    (allow process user_tmp_t ( file ( getattr read write append ioctl lock map open create  ))) 
+    (allow process user_tmp_t ( sock_file ( getattr read write append open  ))) 
+) 

--- a/tests/test_nocontext.podman.json
+++ b/tests/test_nocontext.podman.json
@@ -1,0 +1,362 @@
+[
+    {
+        "ID": "c628734ab412e6856da35e7e47b8cb68dc7d4c1eb663884a6f87a635d14500db",
+        "Created": "2019-06-14T17:21:06.204729556+02:00",
+        "Path": "bash",
+        "Args": [
+            "bash"
+        ],
+        "State": {
+            "OciVersion": "1.0.1-dev",
+            "Status": "running",
+            "Running": true,
+            "Paused": false,
+            "Restarting": false,
+            "OOMKilled": false,
+            "Dead": false,
+            "Pid": 22670,
+            "ExitCode": 0,
+            "Error": "",
+            "StartedAt": "2019-06-14T17:21:06.629710896+02:00",
+            "FinishedAt": "0001-01-01T00:00:00Z",
+            "Healthcheck": {
+                "Status": "",
+                "FailingStreak": 0,
+                "Log": null
+            }
+        },
+        "Image": "26ffec5b4a8ad65083424903b7aa175953329413fe5cc4c0dac6fedbe81f2fbb",
+        "ImageName": "docker.io/library/fedora:latest",
+        "Rootfs": "",
+        "ResolvConfPath": "/var/run/containers/storage/overlay-containers/c628734ab412e6856da35e7e47b8cb68dc7d4c1eb663884a6f87a635d14500db/userdata/resolv.conf",
+        "HostnamePath": "/var/run/containers/storage/overlay-containers/c628734ab412e6856da35e7e47b8cb68dc7d4c1eb663884a6f87a635d14500db/userdata/hostname",
+        "HostsPath": "/var/run/containers/storage/overlay-containers/c628734ab412e6856da35e7e47b8cb68dc7d4c1eb663884a6f87a635d14500db/userdata/hosts",
+        "StaticDir": "/var/lib/containers/storage/overlay-containers/c628734ab412e6856da35e7e47b8cb68dc7d4c1eb663884a6f87a635d14500db/userdata",
+        "LogPath": "/var/lib/containers/storage/overlay-containers/c628734ab412e6856da35e7e47b8cb68dc7d4c1eb663884a6f87a635d14500db/userdata/ctr.log",
+        "ConmonPidFile": "",
+        "Name": "server",
+        "RestartCount": 0,
+        "Driver": "overlay",
+        "MountLabel": "system_u:object_r:container_file_t:s0:c302,c568",
+        "ProcessLabel": "system_u:system_r:container_t:s0:c302,c568",
+        "AppArmorProfile": "",
+        "EffectiveCaps": [
+            "CAP_CHOWN",
+            "CAP_DAC_OVERRIDE",
+            "CAP_FSETID",
+            "CAP_FOWNER",
+            "CAP_MKNOD",
+            "CAP_NET_RAW",
+            "CAP_SETGID",
+            "CAP_SETUID",
+            "CAP_SETFCAP",
+            "CAP_SETPCAP",
+            "CAP_NET_BIND_SERVICE",
+            "CAP_SYS_CHROOT",
+            "CAP_KILL",
+            "CAP_AUDIT_WRITE"
+        ],
+        "BoundingCaps": [
+            "CAP_CHOWN",
+            "CAP_DAC_OVERRIDE",
+            "CAP_FSETID",
+            "CAP_FOWNER",
+            "CAP_MKNOD",
+            "CAP_NET_RAW",
+            "CAP_SETGID",
+            "CAP_SETUID",
+            "CAP_SETFCAP",
+            "CAP_SETPCAP",
+            "CAP_NET_BIND_SERVICE",
+            "CAP_SYS_CHROOT",
+            "CAP_KILL",
+            "CAP_AUDIT_WRITE"
+        ],
+        "ExecIDs": [],
+        "GraphDriver": {
+            "Name": "overlay",
+            "Data": {
+                "LowerDir": "/var/lib/containers/storage/overlay/6034e8155f9cc53fa6e76d11f1639ada5412446e593200bd7de5f6fc19d498c3/diff",
+                "MergedDir": "/var/lib/containers/storage/overlay/fa979455a8f6444928c3fedf9347590a794dddcac6ea268eb63e4fbc666089b5/merged",
+                "UpperDir": "/var/lib/containers/storage/overlay/fa979455a8f6444928c3fedf9347590a794dddcac6ea268eb63e4fbc666089b5/diff",
+                "WorkDir": "/var/lib/containers/storage/overlay/fa979455a8f6444928c3fedf9347590a794dddcac6ea268eb63e4fbc666089b5/work"
+            }
+        },
+        "Mounts": [
+            {
+                "destination": "/sys",
+                "type": "sysfs",
+                "source": "sysfs",
+                "options": [
+                    "nosuid",
+                    "noexec",
+                    "nodev",
+                    "ro"
+                ]
+            },
+            {
+                "destination": "/proc",
+                "type": "proc",
+                "source": "proc",
+                "options": [
+                    "nosuid",
+                    "noexec",
+                    "nodev"
+                ]
+            },
+            {
+                "destination": "/dev",
+                "type": "tmpfs",
+                "source": "tmpfs",
+                "options": [
+                    "nosuid",
+                    "strictatime",
+                    "mode=755",
+                    "size=65536k",
+                    "tmpcopyup"
+                ]
+            },
+            {
+                "destination": "/etc/resolv.conf",
+                "type": "bind",
+                "source": "/var/run/containers/storage/overlay-containers/c628734ab412e6856da35e7e47b8cb68dc7d4c1eb663884a6f87a635d14500db/userdata/resolv.conf",
+                "options": [
+                    "bind",
+                    "private"
+                ]
+            },
+            {
+                "destination": "/dev/mqueue",
+                "type": "mqueue",
+                "source": "mqueue",
+                "options": [
+                    "nosuid",
+                    "noexec",
+                    "nodev"
+                ]
+            },
+            {
+                "destination": "/dev/pts",
+                "type": "devpts",
+                "source": "devpts",
+                "options": [
+                    "nosuid",
+                    "noexec",
+                    "newinstance",
+                    "ptmxmode=0666",
+                    "mode=0620",
+                    "gid=5"
+                ]
+            },
+            {
+                "destination": "/tmp/test",
+                "type": "bind",
+                "source": "/tmp/test",
+                "options": [
+                    "rbind",
+                    "rw",
+                    "rprivate",
+                    "nosuid",
+                    "nodev"
+                ]
+            },
+            {
+                "destination": "/etc/hosts",
+                "type": "bind",
+                "source": "/var/run/containers/storage/overlay-containers/c628734ab412e6856da35e7e47b8cb68dc7d4c1eb663884a6f87a635d14500db/userdata/hosts",
+                "options": [
+                    "bind",
+                    "private"
+                ]
+            },
+            {
+                "destination": "/dev/shm",
+                "type": "bind",
+                "source": "/var/lib/containers/storage/overlay-containers/c628734ab412e6856da35e7e47b8cb68dc7d4c1eb663884a6f87a635d14500db/userdata/shm",
+                "options": [
+                    "bind",
+                    "private"
+                ]
+            },
+            {
+                "destination": "/etc/hostname",
+                "type": "bind",
+                "source": "/var/run/containers/storage/overlay-containers/c628734ab412e6856da35e7e47b8cb68dc7d4c1eb663884a6f87a635d14500db/userdata/hostname",
+                "options": [
+                    "bind",
+                    "private"
+                ]
+            },
+            {
+                "destination": "/run/.containerenv",
+                "type": "bind",
+                "source": "/var/run/containers/storage/overlay-containers/c628734ab412e6856da35e7e47b8cb68dc7d4c1eb663884a6f87a635d14500db/userdata/.containerenv",
+                "options": [
+                    "bind",
+                    "private"
+                ]
+            },
+            {
+                "destination": "/run/secrets",
+                "type": "bind",
+                "source": "/var/run/containers/storage/overlay-containers/c628734ab412e6856da35e7e47b8cb68dc7d4c1eb663884a6f87a635d14500db/userdata/run/secrets",
+                "options": [
+                    "bind",
+                    "private"
+                ]
+            },
+            {
+                "destination": "/sys/fs/cgroup",
+                "type": "cgroup",
+                "source": "cgroup",
+                "options": [
+                    "rprivate",
+                    "nosuid",
+                    "noexec",
+                    "nodev",
+                    "relatime",
+                    "ro"
+                ]
+            }
+        ],
+        "Dependencies": [],
+        "NetworkSettings": {
+            "Bridge": "",
+            "SandboxID": "",
+            "HairpinMode": false,
+            "LinkLocalIPv6Address": "",
+            "LinkLocalIPv6PrefixLen": 0,
+            "Ports": [],
+            "SandboxKey": "/var/run/netns/cni-09fb9efe-fec9-01a6-ba93-c0919b59b9e7",
+            "SecondaryIPAddresses": null,
+            "SecondaryIPv6Addresses": null,
+            "EndpointID": "",
+            "Gateway": "10.88.0.1",
+            "GlobalIPv6Address": "",
+            "GlobalIPv6PrefixLen": 0,
+            "IPAddress": "10.88.0.75",
+            "IPPrefixLen": 16,
+            "IPv6Gateway": "",
+            "MacAddress": "f6:65:7b:a2:3d:10"
+        },
+        "ExitCommand": [
+            "/usr/bin/podman",
+            "--root",
+            "/var/lib/containers/storage",
+            "--runroot",
+            "/var/run/containers/storage",
+            "--log-level",
+            "error",
+            "--cgroup-manager",
+            "systemd",
+            "--tmpdir",
+            "/var/run/libpod",
+            "--runtime",
+            "runc",
+            "--storage-driver",
+            "overlay",
+            "container",
+            "cleanup",
+            "--rm",
+            "c628734ab412e6856da35e7e47b8cb68dc7d4c1eb663884a6f87a635d14500db"
+        ],
+        "Namespace": "",
+        "IsInfra": false,
+        "HostConfig": {
+            "ContainerIDFile": "",
+            "LogConfig": null,
+            "NetworkMode": "bridge",
+            "PortBindings": null,
+            "AutoRemove": true,
+            "CapAdd": [],
+            "CapDrop": [],
+            "DNS": [],
+            "DNSOptions": [],
+            "DNSSearch": [],
+            "ExtraHosts": null,
+            "GroupAdd": null,
+            "IpcMode": "",
+            "Cgroup": "host",
+            "OomScoreAdj": 0,
+            "PidMode": "",
+            "Privileged": false,
+            "PublishAllPorts": false,
+            "ReadonlyRootfs": false,
+            "ReadonlyTmpfs": true,
+            "SecurityOpt": [],
+            "UTSMode": "",
+            "UsernsMode": "",
+            "ShmSize": 65536000,
+            "Runtime": "runc",
+            "ConsoleSize": null,
+            "CpuShares": null,
+            "Memory": 0,
+            "NanoCpus": 0,
+            "CgroupParent": "",
+            "BlkioWeight": null,
+            "BlkioWeightDevice": null,
+            "BlkioDeviceReadBps": null,
+            "BlkioDeviceWriteBps": null,
+            "BlkioDeviceReadIOps": null,
+            "BlkioDeviceWriteIOps": null,
+            "CpuPeriod": null,
+            "CpuQuota": null,
+            "CpuRealtimePeriod": null,
+            "CpuRealtimeRuntime": null,
+            "CpuSetCpus": "",
+            "CpuSetMems": "",
+            "Devices": null,
+            "DiskQuota": 0,
+            "KernelMemory": null,
+            "MemoryReservation": null,
+            "MemorySwap": null,
+            "MemorySwappiness": null,
+            "OomKillDisable": false,
+            "PidsLimit": null,
+            "Ulimits": [],
+            "CpuCount": 0,
+            "CpuPercent": 0,
+            "IOMaximumIOps": 0,
+            "IOMaximumBandwidth": 0,
+            "Tmpfs": []
+        },
+        "Config": {
+            "Hostname": "",
+            "Domainname": "",
+            "User": {
+                "uid": 0,
+                "gid": 0
+            },
+            "AttachStdin": false,
+            "AttachStdout": false,
+            "AttachStderr": false,
+            "Tty": true,
+            "OpenStdin": true,
+            "StdinOnce": false,
+            "Env": [
+                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+                "TERM=xterm",
+                "HOSTNAME=",
+                "container=podman",
+                "DISTTAG=f29container",
+                "FGC=f29",
+                "FBR=f29"
+            ],
+            "Cmd": [
+                "bash"
+            ],
+            "Image": "docker.io/library/fedora:latest",
+            "Volumes": null,
+            "WorkingDir": "/",
+            "Entrypoint": "",
+            "Labels": {
+                "maintainer": "Clement Verna \u003ccverna@fedoraproject.org\u003e"
+            },
+            "Annotations": {
+                "io.kubernetes.cri-o.ContainerType": "sandbox",
+                "io.kubernetes.cri-o.TTY": "true"
+            },
+            "StopSignal": 15
+        }
+    }
+]

--- a/udica/policy.py
+++ b/udica/policy.py
@@ -18,6 +18,7 @@ import semanage
 
 from shutil import copy
 from os import chdir, getcwd, write, read, remove, replace
+from os.path import exists
 
 import tarfile
 
@@ -61,6 +62,10 @@ def list_contexts(directory):
 
     selabel = selinux.selabel_open(selinux.SELABEL_CTX_FILE, None, 0)
     (rc, context) = selinux.selabel_lookup(selabel, directory, 0)
+    if context == None:
+        if exists(directory) == False:
+            exit(3)
+        context = selinux.getfilecon(directory)[1]
     contexts.append(context.split(':')[2])
     return contexts
 


### PR DESCRIPTION
Previously, when SELinux context was not defined in SELinux context
database, like in example below, udica crashed when tried to get context
of such a directory.
This commit fixes the issue by using selinux.getfilecon to get SELinux
context of such a file from extended attributes of the filesystem.

Fixes: #26
```

 #matchpathcon /tmp/test
 /tmp/test	<<none>>

 # podman run -it --rm --name server -v /tmp/test:/tmp/test fedora:latest bash
 # podman inspect -l | sudo udica testudica
 Traceback (most recent call last):
   File "/bin/udica", line 11, in <module>
     load_entry_point('udica==0.1.7', 'console_scripts', 'udica')()
   File "/usr/lib/python3.7/site-packages/udica/__main__.py", line 109, in main
     create_policy(opts, container_caps, container_mounts, container_ports)
   File "/usr/lib/python3.7/site-packages/udica/policy.py", line 173, in create_policy
     contexts = list_contexts(item['source'])
   File "/usr/lib/python3.7/site-packages/udica/policy.py", line 65, in list_contexts
     contexts.append(context.split(':')[2])
```