### PR TITLE
Clean up the test helper

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -34,75 +34,12 @@ SELINUX_ENABLED = False
 class TestMain(unittest.TestCase):
     """Test basic functionality of udica"""
 
-    def test_basic_podman(self):
-        """podman run -v /home:/home:ro -v /var/spool:/var/spool:rw -p 21:21 fedora"""
-        args = ['udica', '-j', 'test_basic.podman.json', 'my_container']
-        self.helper(args, 'test_basic.podman.cil',
-                    '{base_container.cil,net_container.cil,home_container.cil}')
-
-    def test_basic_docker(self):
-        """docker run -v /home:/home:ro -v /var/spool:/var/spool:rw -p 21:21 fedora"""
-        args = ['udica', '-j', 'test_basic.docker.json', 'my_container']
-        self.helper(args, 'test_basic.docker.cil',
-                    '{base_container.cil,net_container.cil,home_container.cil}')
-
-    def test_default_podman(self):
-        """podman run fedora"""
-        args = ['udica', '-j', 'test_default.podman.json', 'my_container']
-        self.helper(args, 'test_default.podman.cil', 'base_container.cil')
-
-    def test_default_docker(self):
-        """docker run fedora"""
-        args = ['udica', '-j', 'test_default.docker.json', 'my_container']
-        self.helper(args, 'test_default.docker.cil', 'base_container.cil')
-
-    def test_port_ranges_podman(self):
-        """podman run -p 63140:63140 fedora"""
-        args = ['udica', '-j', 'test_ports.podman.json', 'my_container']
-        self.helper(args, 'test_ports.podman.cil', '{base_container.cil,net_container.cil}')
-
-    def test_port_ranges_docker(self):
-        """docker run -p 63140:63140 fedora"""
-        args = ['udica', '-j', 'test_ports.docker.json', 'my_container']
-        self.helper(args, 'test_ports.docker.cil', '{base_container.cil,net_container.cil}')
-
-    def test_default_ansible_podman(self):
-        """podman run fedora"""
-        args = ['udica', '-j', 'test_default.podman.json', 'my_container', '--ansible']
-        self.helper(args, 'test_default.podman.cil', 'base_container.cil',
-                    'test_default.ansible.podman.yml')
-
-    def test_basic_ansible_podman(self):
-        """podman run -v /home:/home:ro -v /var/spool:/var/spool:rw -p 21:21 fedora"""
-        args = ['udica', '-j', 'test_basic.podman.json', 'my_container', '--ansible']
-        self.helper(args, 'test_basic.podman.cil',
-                    '{base_container.cil,net_container.cil,home_container.cil}',
-                    'test_basic.ansible.podman.yml')
-
-    def test_nocontext_podman(self):
-        """podman run -v /tmp/test:/tmp/test:rw fedora"""
-        args = ['udica', '-j', 'test_nocontext.podman.json', 'my_container']
-        self.helper(args, 'test_nocontext.podman.cil',
-                    'base_container.cil')
-
-    def helper(self, args, policy_file=None, templates=None, variables_file=None):
-        """Run udica with args, check output and used templates.
-
-        Arguments:
-        args -- list of program arguments (the first one is an executable name)
-        policy_file -- check that output of udica matches this file
-        templates -- check that these templates are part of udica output, e.g. 'base_container.cil'
-            or '{base_container.cil,net_container.cil}'
-        variables_file -- check that output of udica matches variables file
-        """
+    def setUp(self):
         # Overwrite paths to files so that they do not have to be installed.
         udica.policy.TEMPLATE_PLAYBOOK = "../udica/ansible/deploy-module.yml"
         udica.policy.TEMPLATES_STORE = "../udica/templates"
         # FIXME: the policy module is using global variable which must be reset to []
         udica.policy.templates_to_load = []
-
-        # Create /tmp/test directory for proper testing objects without SELinux context specified
-        os.makedirs("/tmp/test", exist_ok=True)
 
         # Remove current directory from sys.path so that the proper selinux and semanage modules are
         # loaded (instead of the mock ones in this directory).
@@ -118,6 +55,69 @@ class TestMain(unittest.TestCase):
         if SELINUX_ENABLED:
             sys.path = path_backup
 
+    def tearDown(self):
+        os.unlink('my_container.cil')
+
+    def test_basic_podman(self):
+        """podman run -v /home:/home:ro -v /var/spool:/var/spool:rw -p 21:21 fedora"""
+        output = self.run_udica(['udica', '-j', 'test_basic.podman.json', 'my_container'])
+        self.assert_templates(output, ['base_container', 'net_container', 'home_container'])
+        self.assert_policy('test_basic.podman.cil')
+
+    def test_basic_docker(self):
+        """docker run -v /home:/home:ro -v /var/spool:/var/spool:rw -p 21:21 fedora"""
+        output = self.run_udica(['udica', '-j', 'test_basic.docker.json', 'my_container'])
+        self.assert_templates(output, ['base_container', 'net_container', 'home_container'])
+        self.assert_policy('test_basic.docker.cil')
+
+    def test_default_podman(self):
+        """podman run fedora"""
+        output = self.run_udica(['udica', '-j', 'test_default.podman.json', 'my_container'])
+        self.assert_templates(output, ['base_container'])
+        self.assert_policy('test_default.podman.cil')
+
+    def test_default_docker(self):
+        """docker run fedora"""
+        output = self.run_udica(['udica', '-j', 'test_default.docker.json', 'my_container'])
+        self.assert_templates(output, ['base_container'])
+        self.assert_policy('test_default.docker.cil')
+
+    def test_port_ranges_podman(self):
+        """podman run -p 63140:63140 fedora"""
+        output = self.run_udica(['udica', '-j', 'test_ports.podman.json', 'my_container'])
+        self.assert_templates(output, ['base_container', 'net_container'])
+        self.assert_policy('test_ports.podman.cil')
+
+    def test_port_ranges_docker(self):
+        """docker run -p 63140:63140 fedora"""
+        output = self.run_udica(['udica', '-j', 'test_ports.docker.json', 'my_container'])
+        self.assert_templates(output, ['base_container', 'net_container'])
+        self.assert_policy('test_ports.docker.cil')
+
+    def test_default_ansible_podman(self):
+        """podman run fedora"""
+        output = self.run_udica(['udica', '-j', 'test_default.podman.json', 'my_container',
+                                 '--ansible'])
+        self.assert_ansible(output, ['base_container'], 'test_default.ansible.podman.yml')
+        self.assert_policy('test_default.podman.cil')
+
+    def test_basic_ansible_podman(self):
+        """podman run -v /home:/home:ro -v /var/spool:/var/spool:rw -p 21:21 fedora"""
+        output = self.run_udica(['udica', '-j', 'test_basic.podman.json', 'my_container',
+                                 '--ansible'])
+        self.assert_ansible(output, ['base_container', 'net_container', 'home_container'],
+                            'test_basic.ansible.podman.yml')
+        self.assert_policy('test_basic.podman.cil')
+
+    def test_nocontext_podman(self):
+        """podman run -v /tmp/test:/tmp/test:rw fedora"""
+        os.makedirs("/tmp/test", exist_ok=True)
+        output = self.run_udica(['udica', '-j', 'test_nocontext.podman.json', 'my_container'])
+        self.assert_templates(output, ['base_container'])
+        self.assert_policy('test_nocontext.podman.cil')
+        os.rmdir("/tmp/test")
+
+    def run_udica(self, args):
         with patch('sys.argv', args):
             with patch('sys.stderr.write') as mock_err, patch('sys.stdout.write') as mock_out:
                 mock_out.output = ""
@@ -130,55 +130,54 @@ class TestMain(unittest.TestCase):
         self.assertRegex(mock_out.output, 'Policy my_container created')
         self.assertRegex(mock_out.output, '--security-opt label=type:my_container.process')
 
-        if "--ansible" in args:
-            udica.policy.TEMPLATES_STORE = "./"
-            self.assertRegex(mock_out.output,
-                             'Ansible playbook and archive with udica policies generated!')
-            with tarfile.open("my_container-policy.tar.gz") as archive:
-                archive.extractall()
-        else:
-            self.assertRegex(mock_out.output, 'semodule -i my_container')
-            if templates:
-                self.assertRegex(mock_out.output, udica.policy.TEMPLATES_STORE + '/' + templates)
+        return mock_out.output
 
+    def assert_templates(self, output, templates):
+        self.assertRegex(output, 'semodule -i my_container')
+        if templates:
+            if len(templates) > 1:
+                templ_str = '{%s.cil}' % '.cil,'.join(templates)
+            else:
+                templ_str = templates[0] + '.cil'
+            self.assertRegex(output, udica.policy.TEMPLATES_STORE + '/' + templ_str)
+
+    def assert_policy(self, policy_file):
         self.assertTrue(os.path.isfile('my_container.cil'))
+        with open('my_container.cil') as cont:
+            policy = cont.read().strip()
+        with open(policy_file) as cont:
+            exp_policy = cont.read().strip()
+        self.assertMultiLineEqual(policy, exp_policy)
 
-        if policy_file:
-            with open('my_container.cil') as cont:
-                policy = cont.read().strip()
-            with open(policy_file) as cont:
-                exp_policy = cont.read().strip()
-            self.assertMultiLineEqual(policy, exp_policy)
+    def assert_ansible(self, output, templates, variables_file):
+        udica.policy.TEMPLATES_STORE = "./"
+        self.assertRegex(output,
+                         'Ansible playbook and archive with udica policies generated!')
+        with tarfile.open("my_container-policy.tar.gz") as archive:
+            archive.extractall()
 
-        os.unlink('my_container.cil')
+        self.assertTrue(os.path.isfile('deploy-module.yml'))
 
-        if "--ansible" in args:
-            self.assertTrue(os.path.isfile('deploy-module.yml'))
+        with open('deploy-module.yml') as cont:
+            playbook = cont.read().strip()
+        with open(udica.policy.TEMPLATE_PLAYBOOK) as cont:
+            exp_playbook = cont.read().strip()
+        self.assertMultiLineEqual(playbook, exp_playbook)
 
-            with open('deploy-module.yml') as cont:
-                playbook = cont.read().strip()
-            with open(udica.policy.TEMPLATE_PLAYBOOK) as cont:
-                exp_playbook = cont.read().strip()
-            self.assertMultiLineEqual(playbook, exp_playbook)
+        self.assertTrue(os.path.isfile('variables-deploy-module.yml'))
 
-            self.assertTrue(os.path.isfile('variables-deploy-module.yml'))
+        with open('variables-deploy-module.yml') as cont:
+            variables_playbook = cont.read().strip()
+        with open(variables_file) as cont:
+            exp_variables_playbook = cont.read().strip()
+        self.assertMultiLineEqual(variables_playbook, exp_variables_playbook)
 
-            with open('variables-deploy-module.yml') as cont:
-                variables_playbook = cont.read().strip()
-            with open(variables_file) as cont:
-                exp_variables_playbook = cont.read().strip()
-            self.assertMultiLineEqual(variables_playbook, exp_variables_playbook)
+        os.unlink('variables-deploy-module.yml')
+        os.unlink('my_container-policy.tar.gz')
+        os.unlink('deploy-module.yml')
 
-            os.unlink('variables-deploy-module.yml')
-            os.unlink('my_container-policy.tar.gz')
-            os.unlink('deploy-module.yml')
-
-            list_templates = templates.strip('{,}').split(',')
-            for template in list_templates:
-                os.unlink(template)
-
-        # Delete /tmp/test directory for proper testing objects without SELinux context specified
-        os.rmdir("/tmp/test")
+        for temp in templates:
+            os.unlink(temp + '.cil')
 
 if __name__ == "__main__":
     if 'selinux_enabled' in sys.argv:


### PR DESCRIPTION
Split large helper function into several smaller ones. Move reloading of
modules and setup tasks to setUp() function. Create run_udica() function
for running udica and recording its output. Create assert_templates()
function for checking generated templates. Create assert_policy()
function for comparing generated policy with a file. Create
assert_ansible() function for checking files generated for ansible.