### PR TITLE
Unify exit codes

### DIFF
--- a/udica/__main__.py
+++ b/udica/__main__.py
@@ -67,7 +67,7 @@ def main():
 
         if not container_inspect_data:
             print('Container with specified ID does not exits!')
-            exit(2)
+            exit(3)
 
     if opts['JsonFile']:
         if opts['JsonFile'] == '-':
@@ -80,7 +80,7 @@ def main():
                     container_inspect_data = f.read()
             else:
                 print('Json file does not exists!')
-                exit(2)
+                exit(3)
 
     if (not opts['JsonFile']) and (not opts['ContainerID']):
         try:
@@ -88,21 +88,21 @@ def main():
             container_inspect_data = sys.stdin.read()
         except Exception as e:
             print('Couldn\'t parse inspect data from stdin:', e)
-            exit(2)
+            exit(3)
 
     try:
         container_inspect = parse_inspect(container_inspect_data)
     except Exception as e:
         print('Couldn\'t parse inspect data:', e)
-        exit(2)
+        exit(3)
     container_mounts = container_inspect[0]['Mounts']
     container_ports = container_inspect[0]['NetworkSettings']['Ports']
 
     try:
-        return_code_podman = parse_is_podman(container_inspect_data)
+        is_podman = parse_is_podman(container_inspect_data)
     except Exception as e:
         print('Couldn\'t parse podman:', e)
-        exit(2)
+        exit(3)
 
     container_caps = []
 
@@ -112,10 +112,14 @@ def main():
         else:
             container_caps = opts['Caps'].split(',')
     else:
-        if return_code_podman == 0:
+        if is_podman:
             container_caps = container_inspect[0]['EffectiveCaps']
 
-    create_policy(opts, container_caps, container_mounts, container_ports)
+    try:
+        create_policy(opts, container_caps, container_mounts, container_ports)
+    except Exception as e:
+        print('Couldn\'t create policy:', e)
+        exit(4)
 
     print('\nPolicy ' + opts['ContainerName'] + ' created!')
 

--- a/udica/man/man8/udica.8
+++ b/udica/man/man8/udica.8
@@ -64,6 +64,23 @@ Allow a container to communicate with the X server
 .I   \-\-virt\-access
 Allow a container to communicate with libvirt
 
+.SH EXIT STATUS
+.TP
+.B 0
+no errors encountered.
+.TP
+.B 1
+other errors.
+.TP
+.B 2
+error while parsing options.
+.TP
+.B 3
+error while getting container info.
+.TP
+.B 4
+error while creating an SELinux policy.
+
 .SH EXAMPLES
 .nf
 # cat my_con.json | udica \-\-x\-access \-\-full\-network\-access my_container

--- a/udica/parse.py
+++ b/udica/parse.py
@@ -44,7 +44,4 @@ def parse_cap(data):
 
 def parse_is_podman(data):
     json_rep = json.loads(data)
-    if 'container=podman' in json_rep[0]['Config']['Env']:
-        return 0
-    else:
-        return 1
+    return 'container=podman' in json_rep[0]['Config']['Env']

--- a/udica/policy.py
+++ b/udica/policy.py
@@ -64,7 +64,7 @@ def list_contexts(directory):
     (rc, context) = selinux.selabel_lookup(selabel, directory, 0)
     if context == None:
         if exists(directory) == False:
-            exit(3)
+            exit(1)
         context = selinux.getfilecon(directory)[1]
     contexts.append(context.split(':')[2])
     return contexts


### PR DESCRIPTION
Return 3 on container-related issues, 4 on SELinux related issues.
Return 2 when supplied invalid options and 1 on other errors. Update man
page.