### PR TITLE
New feature: Cross Container Communication

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -117,6 +117,12 @@ class TestMain(unittest.TestCase):
         self.assert_policy('test_nocontext.podman.cil')
         os.rmdir("/tmp/test")
 
+    def test_stream_connect_podman(self):
+        """podman run fedora"""
+        output = self.run_udica(['udica', '-j', 'test_default.podman.json', '--stream-connect', 'network_container', 'my_container'])
+        self.assert_templates(output, ['base_container'])
+        self.assert_policy('test_stream_connect.podman.cil')
+
     def test_fullnetworkaccess_podman(self):
         """podman run fedora"""
         output = self.run_udica(['udica', '-j', 'test_default.podman.json', '--full-network-access', 'my_container'])

--- a/tests/test_stream_connect.podman.cil
+++ b/tests/test_stream_connect.podman.cil
@@ -1,0 +1,7 @@
+(block my_container
+    (blockinherit container)
+    (allow process network_container.process ( unix_stream_socket ( connectto ))) 
+    (allow process network_container.socket ( sock_file ( getattr write open append ))) 
+    (allow process process ( capability ( chown dac_override fsetid fowner mknod net_raw setgid setuid setfcap setpcap net_bind_service sys_chroot kill audit_write ))) 
+
+)

--- a/udica/__main__.py
+++ b/udica/__main__.py
@@ -38,6 +38,8 @@ def get_args():
     parser.add_argument(
         '--virt-access', help='Allow container to communicate with libvirt ', required=False, dest='VirtAccess', action='store_true')
     parser.add_argument(
+        '-s','--stream-connect', help='Allow container to stream connect with given SELinux domain ', required=False, dest='StreamConnect')
+    parser.add_argument(
         '-l', '--load-modules', help='Load templates and module created by this tool ', required=False, dest='LoadModules', action='store_true')
     parser.add_argument(
         '-c', '--caps', help='List of capabilities, e.g "-c AUDIT_WRITE,CHOWN,DAC_OVERRIDE,FOWNER,FSETID,KILL,MKNOD,NET_BIND_SERVICE,NET_RAW,SETFCAP,SETGID,SETPCAP,SETUID,SYS_CHROOT"', required=False, dest='Caps', default=None)

--- a/udica/man/man8/udica.8
+++ b/udica/man/man8/udica.8
@@ -53,6 +53,10 @@ List of capabilities, for example: "\-c AUDIT\_WRITE,CHOWN,DAC\_OVERRIDE,FOWNER,
 Append more SELinux allow rules generated from SELinux denials in audit daemon.
 
 .TP
+.I  \-s, \-\-stream-connect DOMAIN
+Allow container to stream connect with given SELinux domain.
+
+.TP
 .I   \-\-full\-network\-access
 Allow a container full network access
 

--- a/udica/policy.py
+++ b/udica/policy.py
@@ -115,6 +115,10 @@ def create_policy(opts, capabilities, mounts, ports, append_rules):
         policy.write('    (blockinherit restricted_net_container)\n')
         add_template("net_container")
 
+    if opts['StreamConnect']:
+        policy.write('    (allow process ' + opts['StreamConnect'] + '.process ( unix_stream_socket ( connectto ))) \n')
+        policy.write('    (allow process ' + opts['StreamConnect'] + '.socket ( sock_file ( getattr write open append ))) \n')
+
     # capabilities
     if capabilities:
         caps = ''

--- a/udica/templates/base_container.cil
+++ b/udica/templates/base_container.cil
@@ -1,9 +1,12 @@
 (block container
 (type process)
+(type socket)
 (roletype system_r process)
 (typeattributeset domain (process ))
 (typeattributeset container_domain (process ))
 (typeattributeset svirt_sandbox_domain (process ))
+(typeattributeset file_type (socket ))
+(allow process socket (sock_file (create open getattr setattr read write rename link unlink ioctl lock append)))
 (allow process proc_type (file (getattr open read)))
 (allow process cpu_online_t (file (getattr open read)))
 (allow container_runtime_t process (key (create link read search setattr view write)))


### PR DESCRIPTION
This feature allows specify container communication using stream sockets.

Communication is specified via new parameter "--stream-connect".
Feature example:
  
    Create containerA:
    # udica -j containerA.json containerA

    Create containerB which could stream connect to containerA:
    # udica -j containerB.json --stream-connect containerA containerB

Now, containerB contains following additional rules and communicate with
containerA via stream socket:
    allow containerB.process containerA.process:unix_stream_socket connectto;
    allow containerB.process containerA.socket ( sock_file ( getattr write open append )))

This feature also add new object to base container template for creating
socket file under every container namespace. e.g: my_container.socket,
network_container.socket.