### PR TITLE
Improve permission set for log_container template

### DIFF
--- a/udica/templates/log_container.cil
+++ b/udica/templates/log_container.cil
@@ -12,12 +12,12 @@
 (block log_rw_container
     (blockinherit log_container)
 
-    (allow process logfile (dir (getattr search open)))
-    (allow process logfile (file (ioctl read write getattr lock append open)))
+    (allow process logfile (dir (ioctl read write create getattr setattr lock add_name search open)))
+    (allow process logfile (file (ioctl read write create getattr setattr lock append open)))
     (allow process logfile (lnk_file (ioctl read write getattr lock append open)))
     (allow process var_t (dir (getattr search open)))
-    (allow process auditd_log_t (dir (ioctl read write getattr lock search open)))
-    (allow process auditd_log_t (file (ioctl read write getattr lock open)))
+    (allow process auditd_log_t (dir (ioctl read getattr lock search open)))
+    (allow process auditd_log_t (file (ioctl read getattr lock open)))
 )
 
 (block log_manage_container
@@ -26,5 +26,6 @@
     (allow process logfile (dir (ioctl read write create getattr setattr lock unlink link rename add_name remove_name reparent search rmdir open)))
     (allow process logfile (file (ioctl read write create getattr setattr lock append unlink link rename open)))
     (allow process logfile (lnk_file (ioctl read write create getattr setattr lock append unlink link rename)))
-
+    (allow process auditd_log_t (dir (ioctl read write getattr lock search open)))
+    (allow process auditd_log_t (file (ioctl read write getattr lock open)))
 )


### PR DESCRIPTION
For the log_rw_container it wasn't possible to create new files, which
is something that's normally required. So we're adding this
capability, while still not allowing that container to rename that
directory or remove files from it as a security measure.

The audit_log_t file was also modified to be more restrictive for the
log_rw_container block, so we only allow reads now. However, the write
capability was left for the log_manage_container block.