### PR TITLE
Add Dockerfile for udica container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM fedora:30
+
+USER root
+
+# Update image
+RUN dnf update --disableplugin=subscription-manager -y && \
+    rm -rf /var/cache/yum
+
+# Install dependencies
+RUN dnf install --disableplugin=subscription-manager -y \
+            python3 \
+            python3-setools \
+            systemd-devel \
+            policycoreutils \
+            policycoreutils-python-utils \
+    && rm -rf /var/cache/yum
+
+# build udica
+WORKDIR /tmp
+COPY udica/ udica/udica/
+COPY LICENSE udica/
+COPY README.md udica/
+COPY setup.py udica/
+WORKDIR /tmp/udica
+RUN python3 setup.py install
+WORKDIR /
+
+# Clean up
+RUN rm -rf /tmp/udica/
+
+ENTRYPOINT ["/usr/bin/udica"]

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+TAG ?= latest
+IMAGE_NAME ?= udica
+CONTAINER_CMD ?= podman
+
 .PHONY: install
 install:
 	python3 setup.py install
@@ -5,3 +9,7 @@ install:
 .PHONY: test
 test:
 	python3 -m unittest -v tests/test_unit.py
+
+.PHONY: image
+image:
+	$(CONTAINER_CMD) build -f Dockerfile -t $(IMAGE_NAME):$(TAG)

--- a/README.md
+++ b/README.md
@@ -169,6 +169,27 @@ Proof that SELinux allows binding only to tcp/udp *21* port.
     Ncat: SHA-1 fingerprint: 6EEC 102E 6666 5F96 CC4F E5FA A1BE 4A5E 6C76 B6DC
     Ncat: bind to :::80: Permission denied. QUITTING.
 
+## Running from a container
+
+To build the udica container to your local registry, run the following command:
+
+    $ make image
+
+Once having the image built, it's possible to run udica from whithin a
+container. The necessary directories to bind-mount are:
+
+* `/sys/fs/selinux`
+* `/etc/selinux/`
+* `/var/lib/selinux/`
+
+For reference, this would be a way to call the container via podman:
+
+    podman run --user root --privileged -ti \
+        -v /sys/fs/selinux:/sys/fs/selinux \
+        -v /etc/selinux/:/etc/selinux/ \
+        -v /var/lib/selinux/:/var/lib/selinux/ \
+        --rm --name=udica udica
+
 ## Testing
 
 Udica repository contains units tests for basic functionality of the tool. To run tests follow these commands:


### PR DESCRIPTION
This adds a dockerfile which allows you to build a container for udica
from source.

It also includes a Makefile that'll allow you to build the image with
your preferred command (the default is podman and the default tag is
"latest").

Note that in ordre to use udica as a container, you need to bind-mount
the following directories to it:

* /sys/fs/selinux

* /etc/selinux

* /var/lib/selinux