### PR TITLE
udica/policy.py: Remove unused imports

### DIFF
--- a/udica/policy.py
+++ b/udica/policy.py
@@ -13,14 +13,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from shutil import copy
+from os import chdir, getcwd, remove
+from os.path import exists
+import tarfile
+
 import selinux
 import semanage
-
-from shutil import copy
-from os import chdir, getcwd, write, read, remove, replace
-from os.path import exists
-
-import tarfile
 
 import udica.perms as perms
 


### PR DESCRIPTION
Some of the imports in udica/policy.py weren't used. This cleans them
up.

Closes: #41