### PR TITLE
Create Makefile and refactor tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ before_install:
 
 script:
     # test on Fedora Rawhide
-    - docker run -v $PWD:/root/build/ fedora:rawhide /bin/sh -c "cd /root/build; python3 ./setup.py install; cd tests; python3 -m unittest"
+    - docker run -v $PWD:/root/build/ fedora:rawhide /bin/sh -c "cd /root/build; python3 -m unittest -v tests/test_main.py"
     # test on the latest stable release of Fedora
-    - docker run -v $PWD:/root/build/ fedora:latest /bin/sh -c "cd /root/build; python3 ./setup.py install; cd tests; python3 -m unittest"
+    - docker run -v $PWD:/root/build/ fedora:latest /bin/sh -c "cd /root/build; python3 -m unittest -v tests/test_main.py"
 
 notifications:
     emails:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ before_install:
 
 script:
     # test on Fedora Rawhide
-    - docker run -v $PWD:/root/build/ fedora:rawhide /bin/sh -c "cd /root/build; python3 -m unittest -v tests/test_main.py"
+    - docker run -v $PWD:/root/build/ fedora:rawhide /bin/sh -c "cd /root/build; python3 -m unittest -v tests/test_unit.py"
     # test on the latest stable release of Fedora
-    - docker run -v $PWD:/root/build/ fedora:latest /bin/sh -c "cd /root/build; python3 -m unittest -v tests/test_main.py"
+    - docker run -v $PWD:/root/build/ fedora:latest /bin/sh -c "cd /root/build; python3 -m unittest -v tests/test_unit.py"
 
 notifications:
     emails:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: install
+install:
+	python3 setup.py install
+
+.PHONY: test
+test:
+	python3 -m unittest -v tests/test_main.py

--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,4 @@ install:
 
 .PHONY: test
 test:
-	python3 -m unittest -v tests/test_main.py
+	python3 -m unittest -v tests/test_unit.py

--- a/README.md
+++ b/README.md
@@ -173,13 +173,11 @@ Proof that SELinux allows binding only to tcp/udp *21* port.
 
 Udica repository contains units tests for basic functionality of the tool. To run tests follow these commands:
 
-    $ cd tests
-    $ python3 -m unittest
+    $ make test
 
 On SELinux enabled systems you can run also (root access required):
 
-    $ cd tests
-    # python3 test_main.py selinux_enabled
+    # python3 tests/test_integration.py
 
 ## Udica in OpenShift
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,28 @@
+# Copyright (C) 2019 Jan Zarsky, <jzarsky@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import unittest
+import os
+import sys
+
+import test_main
+
+class TestIntegration(test_main.TestBase):
+    """Test basic functionality of udica"""
+
+if __name__ == "__main__":
+    # Very similar to our basic tests, but we don't overwrite the SELinux
+    # modules
+    unittest.main()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -23,141 +23,158 @@ from unittest.mock import patch
 # parameter is used
 import tarfile
 
-sys.path.insert(0, os.path.abspath('..'))
-import udica.__main__
+import tests.selinux as mocked_selinux
+import tests.semanage as mocked_semanage
 
 # Use the selinux and semanage packages provided by the system instead of the mock ones. When
 # running on a system with SELinux disabled (e.g. in a container), it must be set to False.
 # On RHEL, CentOS or Fedora it may be set to True.
 SELINUX_ENABLED = False
 
+# Globally define symbol "udica" so we can override the import
+udica = None
+
+TEST_DIR_PATH = os.path.dirname(os.path.abspath(__file__))
+
+def test_file(path):
+    return os.path.join(TEST_DIR_PATH, path)
+
 class TestMain(unittest.TestCase):
     """Test basic functionality of udica"""
 
     def setUp(self):
+        if not SELINUX_ENABLED:
+            self.selinux_patch = patch.dict('sys.modules',
+                                            selinux=mocked_selinux)
+            self.selinux_patch.start()
+
+            self.semanage_patch = patch.dict('sys.modules',
+                                            semanage=mocked_semanage)
+            self.semanage_patch.start()
+
+        # NOTE: We import udica here so the above mocked modules take place.
+        global udica
+        udica = __import__("udica.__main__")
+
         # Overwrite paths to files so that they do not have to be installed.
-        udica.policy.TEMPLATE_PLAYBOOK = "../udica/ansible/deploy-module.yml"
-        udica.policy.TEMPLATES_STORE = "../udica/templates"
+        udica.policy.TEMPLATE_PLAYBOOK = os.path.join(
+            TEST_DIR_PATH, "../", "udica/ansible/deploy-module.yml")
+        udica.policy.TEMPLATES_STORE = os.path.join(
+            TEST_DIR_PATH, "../", "udica/templates")
         # FIXME: the policy module is using global variable which must be reset to []
         udica.policy.templates_to_load = []
 
-        # Remove current directory from sys.path so that the proper selinux and semanage modules are
-        # loaded (instead of the mock ones in this directory).
-        if SELINUX_ENABLED:
-            path_backup = sys.path
-            sys.path = [path for path in sys.path if path not in (os.getcwd(), '')]
-
-        import selinux
-        importlib.reload(selinux)
-        import semanage
-        importlib.reload(semanage)
-
-        if SELINUX_ENABLED:
-            sys.path = path_backup
-
     def tearDown(self):
+        if not SELINUX_ENABLED:
+            self.selinux_patch.stop()
+            self.semanage_patch.stop()
         os.unlink('my_container.cil')
+
+        global udica
+        udica = None
 
     def test_basic_podman(self):
         """podman run -v /home:/home:ro -v /var/spool:/var/spool:rw -p 21:21 fedora"""
-        output = self.run_udica(['udica', '-j', 'test_basic.podman.json', 'my_container'])
+        output = self.run_udica(['udica', '-j', 'tests/test_basic.podman.json', 'my_container'])
         self.assert_templates(output, ['base_container', 'net_container', 'home_container'])
-        self.assert_policy('test_basic.podman.cil')
+        self.assert_policy(test_file('test_basic.podman.cil'))
 
     def test_basic_docker(self):
         """docker run -v /home:/home:ro -v /var/spool:/var/spool:rw -p 21:21 fedora"""
-        output = self.run_udica(['udica', '-j', 'test_basic.docker.json', 'my_container'])
+        output = self.run_udica(['udica', '-j', 'tests/test_basic.docker.json', 'my_container'])
         self.assert_templates(output, ['base_container', 'net_container', 'home_container'])
-        self.assert_policy('test_basic.docker.cil')
+        self.assert_policy(test_file('test_basic.docker.cil'))
 
     def test_basic_cri(self):
         """Start CRI-O mounting /var/spool with read/write perms and /home with readonly perms"""
-        output = self.run_udica(['udica', '-j', 'test_basic.cri.json', '--full-network-access', 'my_container'])
+        output = self.run_udica(['udica', '-j', 'tests/test_basic.cri.json', '--full-network-access', 'my_container'])
         self.assert_templates(output, ['base_container', 'net_container', 'home_container'])
-        self.assert_policy('test_basic.cri.cil')
+        self.assert_policy(test_file('test_basic.cri.cil'))
 
     def test_default_podman(self):
         """podman run fedora"""
-        output = self.run_udica(['udica', '-j', 'test_default.podman.json', 'my_container'])
+        output = self.run_udica(['udica', '-j', 'tests/test_default.podman.json', 'my_container'])
         self.assert_templates(output, ['base_container'])
-        self.assert_policy('test_default.podman.cil')
+        self.assert_policy(test_file('test_default.podman.cil'))
 
     def test_default_docker(self):
         """docker run fedora"""
-        output = self.run_udica(['udica', '-j', 'test_default.docker.json', 'my_container'])
+        output = self.run_udica(['udica', '-j', 'tests/test_default.docker.json', 'my_container'])
         self.assert_templates(output, ['base_container'])
-        self.assert_policy('test_default.docker.cil')
+        self.assert_policy(test_file('test_default.docker.cil'))
 
     def test_port_ranges_podman(self):
         """podman run -p 63140:63140 fedora"""
-        output = self.run_udica(['udica', '-j', 'test_ports.podman.json', 'my_container'])
+        output = self.run_udica(['udica', '-j', 'tests/test_ports.podman.json', 'my_container'])
         self.assert_templates(output, ['base_container', 'net_container'])
-        self.assert_policy('test_ports.podman.cil')
+        self.assert_policy(test_file('test_ports.podman.cil'))
 
     def test_port_ranges_docker(self):
         """docker run -p 63140:63140 fedora"""
-        output = self.run_udica(['udica', '-j', 'test_ports.docker.json', 'my_container'])
+        output = self.run_udica(['udica', '-j', 'tests/test_ports.docker.json', 'my_container'])
         self.assert_templates(output, ['base_container', 'net_container'])
-        self.assert_policy('test_ports.docker.cil')
+        self.assert_policy(test_file('test_ports.docker.cil'))
 
     def test_default_ansible_podman(self):
         """podman run fedora"""
-        output = self.run_udica(['udica', '-j', 'test_default.podman.json', 'my_container',
+        output = self.run_udica(['udica', '-j', 'tests/test_default.podman.json', 'my_container',
                                  '--ansible'])
-        self.assert_ansible(output, ['base_container'], 'test_default.ansible.podman.yml')
-        self.assert_policy('test_default.podman.cil')
+        self.assert_ansible(output, ['base_container'],
+                            test_file('test_default.ansible.podman.yml'))
+        self.assert_policy(test_file('test_default.podman.cil'))
 
     def test_basic_ansible_podman(self):
         """podman run -v /home:/home:ro -v /var/spool:/var/spool:rw -p 21:21 fedora"""
-        output = self.run_udica(['udica', '-j', 'test_basic.podman.json', 'my_container',
+        output = self.run_udica(['udica', '-j', 'tests/test_basic.podman.json', 'my_container',
                                  '--ansible'])
         self.assert_ansible(output, ['base_container', 'net_container', 'home_container'],
-                            'test_basic.ansible.podman.yml')
-        self.assert_policy('test_basic.podman.cil')
+                            test_file('test_basic.ansible.podman.yml'))
+        self.assert_policy(test_file('test_basic.podman.cil'))
 
     def test_nocontext_podman(self):
         """podman run -v /tmp/test:/tmp/test:rw fedora"""
         os.makedirs("/tmp/test", exist_ok=True)
-        output = self.run_udica(['udica', '-j', 'test_nocontext.podman.json', 'my_container'])
+        output = self.run_udica(['udica', '-j', 'tests/test_nocontext.podman.json', 'my_container'])
         self.assert_templates(output, ['base_container'])
-        self.assert_policy('test_nocontext.podman.cil')
+        self.assert_policy(test_file('test_nocontext.podman.cil'))
         os.rmdir("/tmp/test")
 
     def test_stream_connect_podman(self):
         """podman run fedora"""
-        output = self.run_udica(['udica', '-j', 'test_default.podman.json', '--stream-connect', 'network_container', 'my_container'])
+        output = self.run_udica(['udica', '-j', 'tests/test_default.podman.json', '--stream-connect', 'network_container', 'my_container'])
         self.assert_templates(output, ['base_container'])
-        self.assert_policy('test_stream_connect.podman.cil')
+        self.assert_policy(test_file('test_stream_connect.podman.cil'))
 
     def test_fullnetworkaccess_podman(self):
         """podman run fedora"""
-        output = self.run_udica(['udica', '-j', 'test_default.podman.json', '--full-network-access', 'my_container'])
+        output = self.run_udica(['udica', '-j', 'tests/test_default.podman.json', '--full-network-access', 'my_container'])
         self.assert_templates(output, ['base_container', 'net_container'])
-        self.assert_policy('test_fullnetworkaccess.podman.cil')
+        self.assert_policy(test_file('test_fullnetworkaccess.podman.cil'))
 
     def test_virtaccess_podman(self):
         """podman run fedora"""
-        output = self.run_udica(['udica', '-j', 'test_default.podman.json','--virt-access', 'my_container'])
+        output = self.run_udica(['udica', '-j', 'tests/test_default.podman.json','--virt-access', 'my_container'])
         self.assert_templates(output, ['base_container', 'virt_container'])
-        self.assert_policy('test_virtaccess.podman.cil')
+        self.assert_policy(test_file('test_virtaccess.podman.cil'))
 
     def test_xaccess_podman(self):
         """podman run fedora"""
-        output = self.run_udica(['udica', '-j', 'test_default.podman.json','--X-access', 'my_container'])
+        output = self.run_udica(['udica', '-j', 'tests/test_default.podman.json','--X-access', 'my_container'])
         self.assert_templates(output, ['base_container', 'x_container'])
-        self.assert_policy('test_xaccess.podman.cil')
+        self.assert_policy(test_file('test_xaccess.podman.cil'))
 
     def test_ttyaccess_podman(self):
         """podman run fedora"""
-        output = self.run_udica(['udica', '-j', 'test_default.podman.json','--tty-access', 'my_container'])
+        output = self.run_udica(['udica', '-j', 'tests/test_default.podman.json','--tty-access', 'my_container'])
         self.assert_templates(output, ['base_container', 'tty_container'])
-        self.assert_policy('test_ttyaccess.podman.cil')
+        self.assert_policy(test_file('test_ttyaccess.podman.cil'))
 
     def test_append_more_rules_podman(self):
         """podman run fedora"""
-        output = self.run_udica(['udica', '-j', 'test_default.podman.json','-a', 'append_avc_file', 'my_container'])
+        output = self.run_udica(['udica', '-j', 'tests/test_default.podman.json',
+                                 '-a', 'tests/append_avc_file', 'my_container'])
         self.assert_templates(output, ['base_container'])
-        self.assert_policy('test_append_avc.podman.cil')
+        self.assert_policy(test_file('test_append_avc.podman.cil'))
 
     def run_udica(self, args):
         with patch('sys.argv', args):

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,0 +1,40 @@
+# Copyright (C) 2019 Jan Zarsky, <jzarsky@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import os
+from unittest.mock import patch
+
+import tests.test_main
+import tests.selinux as mocked_selinux
+import tests.semanage as mocked_semanage
+
+class TestUnit(tests.test_main.TestBase):
+    """Test basic functionality of udica"""
+
+    def setUp(self):
+        self.selinux_patch = patch.dict('sys.modules',
+                                        selinux=mocked_selinux)
+        self.selinux_patch.start()
+
+        self.semanage_patch = patch.dict('sys.modules',
+                                         semanage=mocked_semanage)
+        self.semanage_patch.start()
+
+        super().setUp()
+
+    def tearDown(self):
+        self.selinux_patch.stop()
+        self.semanage_patch.stop()
+        super().tearDown()


### PR DESCRIPTION
This creates a very basic Makefile and refactors the tests so they can be ran from the top level directory.

The tests have also been separated into unit tests and integration tests.

The unit tests are what is still being ran on CI, and is what's called from the "test" target in the makefile.

The integration tests can be called directly from the module. e.g. `python3 tests/test_integration.py`, and this will actually require the python SELinux packages to be installed, as well as the udica python package itself (given that we would be testing integration). Currently it runs the same tests as the unit tests, but it can be extended in the future.