### PR TITLE
Make container types mcs-constrained

### DIFF
--- a/udica/templates/base_container.cil
+++ b/udica/templates/base_container.cil
@@ -5,6 +5,7 @@
 (typeattributeset domain (process ))
 (typeattributeset container_domain (process ))
 (typeattributeset svirt_sandbox_domain (process ))
+(typeattributeset mcs_constrained_type (process ))
 (typeattributeset file_type (socket ))
 (allow process socket (sock_file (create open getattr setattr read write rename link unlink ioctl lock append)))
 (allow process proc_type (file (getattr open read)))


### PR DESCRIPTION
`container.process` is currently not mcs-constrained, and so by default, types that inherit container.process are not either.
It is important for such types to enforce that resources with different categories (i.e. pods) won't be able to interact with each other by default.
This PR fixes that.