### PR TITLE
Cirrus: Use images from automation_images

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,9 +20,10 @@ env:
     ####
     # GCE project where images live
     IMAGE_PROJECT: "libpod-218412"
-    _BUILT_IMAGE_SUFFIX: "podman-6530021898584064"  # From libpod's .cirrus.yml
-    FEDORA_CACHE_IMAGE_NAME: "fedora-32-${_BUILT_IMAGE_SUFFIX}"
-    PRIOR_FEDORA_CACHE_IMAGE_NAME: "fedora-31-${_BUILT_IMAGE_SUFFIX}"
+    # VM Image built in containers/automation_images
+    _BUILT_IMAGE_SUFFIX: "c6110627968057344"
+    FEDORA_CACHE_IMAGE_NAME: "fedora-${_BUILT_IMAGE_SUFFIX}"
+    PRIOR_FEDORA_CACHE_IMAGE_NAME: "prior-fedora-${_BUILT_IMAGE_SUFFIX}"
 
     ####
     #### Command variables to help avoid duplication


### PR DESCRIPTION
Previously, VM Images were built from a side-band process tacked onto
containers/podman automation. This has recently been split off into it's
own repository containers/automation_images. This PR makes use of
freshly built images produced using the new workflow. Additionally, to
support testing of a runc -> crun transition, both packages are
installed in the newly referenced images.

Signed-off-by: Chris Evich <cevich@redhat.com>