### PR TITLE
Specify required python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/containers/udica",
     packages=["udica"],
+    python_requires=">=3, <4",
     data_files=[
         ("/usr/share/licenses/udica", ["LICENSE"]),
         ("/usr/share/udica/ansible", ["udica/ansible/deploy-module.yml"]),

--- a/udica/parse.py
+++ b/udica/parse.py
@@ -125,7 +125,7 @@ class DockerHelper(PodmanDockerHelper):
 
     def adjust_json_from_docker(self, json_rep):
         """If the json comes from a docker call, we need to adjust it to make use
-        of it. """
+        of it."""
 
         if not isinstance(json_rep[0]["NetworkSettings"]["Ports"], dict):
             raise Exception(


### PR DESCRIPTION
Prevent Udica instalation under py2 as py3-only is supported.

Signed-off-by: Martin Bašti <mbasti@redhat.com>