### PR TITLE
Sort container inspect data

### DIFF
--- a/tests/test_basic.oci.cil
+++ b/tests/test_basic.oci.cil
@@ -4,6 +4,7 @@
     (allow process process ( capability ( audit_write chown dac_override fowner fsetid kill mknod net_bind_service net_raw setfcap setgid setpcap setuid sys_chroot ))) 
 
     (allow process ftp_port_t ( tcp_socket (  name_bind ))) 
+    (blockinherit home_container)
     (allow process var_spool_t ( dir ( add_name create getattr ioctl lock open read remove_name rmdir search setattr write ))) 
     (allow process var_spool_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write ))) 
     (allow process var_spool_t ( sock_file ( append getattr open read write ))) 
@@ -289,5 +290,4 @@
     (allow process var_spool_t ( dir ( add_name create getattr ioctl lock open read remove_name rmdir search setattr write ))) 
     (allow process var_spool_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write ))) 
     (allow process var_spool_t ( sock_file ( append getattr open read write ))) 
-    (blockinherit home_container)
 )

--- a/udica/__main__.py
+++ b/udica/__main__.py
@@ -213,7 +213,7 @@ def main():
 
     container_caps = []
 
-    container_caps = engine_helper.get_caps(container_inspect, opts)
+    container_caps = sorted(engine_helper.get_caps(container_inspect, opts))
 
     try:
         create_policy(

--- a/udica/policy.py
+++ b/udica/policy.py
@@ -149,7 +149,7 @@ def create_policy(
         policy.write("\n")
 
     # ports
-    for item in ports:
+    for item in sorted(ports, key=lambda x: x.get("portNumber", 0)):
         if "portNumber" in item:
             policy.write(
                 "    (allow process "
@@ -194,7 +194,7 @@ def create_policy(
 
 
 def write_policy_for_crio_mounts(mounts, policy):
-    for item in mounts:
+    for item in sorted(mounts, key=lambda x: str(x["hostPath"])):
         if item["hostPath"].startswith("/var/lib/kubelet"):
             # These should already have the right context
             continue
@@ -281,7 +281,7 @@ def write_policy_for_crio_mounts(mounts, policy):
 
 
 def write_policy_for_podman_devices(devices, policy):
-    for item in devices:
+    for item in sorted(devices, key=lambda x: str(x["PathOnHost"])):
         contexts = list_contexts(item["PathOnHost"])
         for context in contexts:
             policy.write(
@@ -301,7 +301,7 @@ def write_policy_for_podman_devices(devices, policy):
 
 
 def write_policy_for_podman_mounts(mounts, policy):
-    for item in mounts:
+    for item in sorted(mounts, key=lambda x: str(x["Source"])):
         if not item["Source"].find("/"):
             if item["Source"] == LOG_CONTAINER and item["RW"] is False:
                 policy.write("    (blockinherit log_container)\n")


### PR DESCRIPTION
This should diminish differences between policies generated for the same
container (allow rules should be in the same order).

Fixes:  Two subsequent calls to Udica on the same container sometimes
        generate different policy files (functionally equivalent, but
        with different rule order). This issue makes it difficult to use
        udica for CI purposes.

        https://github.com/containers/udica/issues/84

Signed-off-by: Vit Mojzis <vmojzis@redhat.com>