### PR TITLE
Update templates to work properly with new cil parser

### DIFF
--- a/udica/templates/config_container.cil
+++ b/udica/templates/config_container.cil
@@ -1,25 +1,24 @@
 (block config_container
-    (blockinherit container)
-
-    (allow process configfile (dir (ioctl read getattr lock search open)))
-    (allow process configfile (file (ioctl read getattr lock open)))
-    (allow process configfile (lnk_file (read getattr)))
-
+	(optional config_container_optional
+		(allow process configfile (dir (ioctl read getattr lock search open)))
+		(allow process configfile (file (ioctl read getattr lock open)))
+		(allow process configfile (lnk_file (read getattr)))
+	)
 )
 
 (block config_rw_container
-    (blockinherit config_container)
-
-    (allow process configfile (dir (ioctl read write getattr lock append open)))
-    (allow process configfile (file (ioctl read write getattr lock append open)))
-    (allow process configfile (lnk_file (ioctl read write getattr lock append open)))
+	(blockinherit config_container)
+	(optional config_rw_container_optional
+		(allow process configfile (dir (ioctl read write getattr lock append open)))
+		(allow process configfile (file (ioctl read write getattr lock append open)))
+		(allow process configfile (lnk_file (ioctl read write getattr lock append open)))
+	)
 )
 
 (block config_manage_container
-    (blockinherit container)
-
-    (allow process configfile (dir (ioctl read write create getattr setattr lock unlink link rename add_name remove_name reparent search rmdir open)))
-    (allow process configfile (file (ioctl read write create getattr setattr lock append unlink link rename open)))
-    (allow process configfile (lnk_file (ioctl read write create getattr setattr lock append unlink link rename open)))
-
+	(optional config_manage_container_optional
+		(allow process configfile (dir (ioctl read write create getattr setattr lock unlink link rename add_name remove_name reparent search rmdir open)))
+		(allow process configfile (file (ioctl read write create getattr setattr lock append unlink link rename open)))
+		(allow process configfile (lnk_file (ioctl read write create getattr setattr lock append unlink link rename open)))
+	)
 )

--- a/udica/templates/home_container.cil
+++ b/udica/templates/home_container.cil
@@ -1,33 +1,37 @@
 (block home_container
-	(blockinherit container)
+	(optional home_container_optional
+		(allow process process (capability (dac_override )))
 
-    (allow process process (capability (dac_override )))
+		(allow process user_home_dir_t (dir (getattr search open read lock ioctl)))
+		(allow process home_root_t (dir (getattr search open read lock ioctl)))
+		(allow process user_home_t (dir (getattr search open read lock ioctl)))
 
-	(allow process user_home_dir_t (dir (getattr search open read lock ioctl)))
-	(allow process home_root_t (dir (getattr search open read lock ioctl)))
-    (allow process user_home_t (dir (getattr search open read lock ioctl)))
-
-	(allow process user_home_dir_t (file (getattr ioctl lock open read)))
-	(allow process user_home_t (file (getattr ioctl lock open read)))
+		(allow process user_home_dir_t (file (getattr ioctl lock open read)))
+		(allow process user_home_t (file (getattr ioctl lock open read)))
+	)
 )
 
 
 (block home_rw_container
-    (blockinherit home_container)
-	(allow process user_home_dir_t (dir (open getattr setattr read write link search add_name remove_name reparent lock ioctl)))
-	(allow process home_root_t (dir (open getattr setattr read write link search add_name remove_name reparent lock ioctl)))
-	(allow process user_home_t (dir (open getattr setattr read write link search add_name remove_name reparent lock ioctl)))
+	(blockinherit home_container)
+	(optional home_rw_container_optional
+		(allow process user_home_dir_t (dir (open getattr setattr read write link search add_name remove_name reparent lock ioctl)))
+		(allow process home_root_t (dir (open getattr setattr read write link search add_name remove_name reparent lock ioctl)))
+		(allow process user_home_t (dir (open getattr setattr read write link search add_name remove_name reparent lock ioctl)))
 
-	(allow process user_home_t (file (open getattr read write append ioctl lock)))
-	(allow process user_home_dir_t (file (open getattr read write append ioctl lock)))
+		(allow process user_home_t (file (open getattr read write append ioctl lock)))
+		(allow process user_home_dir_t (file (open getattr read write append ioctl lock)))
+	)
 )
 
 (block home_manage_container
-    (blockinherit home_rw_container)
-	(allow process user_home_dir_t (dir (create unlink rename rmdir )))
-	(allow process home_root_t (dir (create unlink rename rmdir )))
-	(allow process user_home_t (dir (create unlink rename rmdir )))
+	(blockinherit home_rw_container)
+	(optional home_manage_container_optional
+		(allow process user_home_dir_t (dir (create unlink rename rmdir )))
+		(allow process home_root_t (dir (create unlink rename rmdir )))
+		(allow process user_home_t (dir (create unlink rename rmdir )))
 
-	(allow process user_home_t (file (create rename link unlink )))
-	(allow process user_home_dir_t (file (create rename link unlink )))
+		(allow process user_home_t (file (create rename link unlink )))
+		(allow process user_home_dir_t (file (create rename link unlink )))
+	)
 )

--- a/udica/templates/log_container.cil
+++ b/udica/templates/log_container.cil
@@ -1,31 +1,35 @@
 (block log_container
-    (blockinherit container)
-
-    (allow process var_t (dir (getattr search open)))
-    (allow process logfile (dir (ioctl read getattr lock search open)))
-    (allow process logfile (file (ioctl read getattr lock open map)))
-    (allow process auditd_log_t (dir (ioctl read getattr lock search open)))
-    (allow process auditd_log_t (file (ioctl read getattr lock open)))
+	(optional log_container_optional
+		(allow process var_t (dir (getattr search open)))
+		(allow process logfile (dir (ioctl read getattr lock search open)))
+		(allow process logfile (file (ioctl read getattr lock open map)))
+		(allow process auditd_log_t (dir (ioctl read getattr lock search open)))
+		(allow process auditd_log_t (file (ioctl read getattr lock open)))
+	)
 )
 
 
 (block log_rw_container
-    (blockinherit log_container)
+	(blockinherit log_container)
 
-    (allow process logfile (dir (ioctl read write create getattr setattr lock add_name search open)))
-    (allow process logfile (file (ioctl read write create getattr setattr lock append open)))
-    (allow process logfile (lnk_file (ioctl read write getattr lock append open)))
-    (allow process var_t (dir (getattr search open)))
-    (allow process auditd_log_t (dir (ioctl read getattr lock search open)))
-    (allow process auditd_log_t (file (ioctl read getattr lock open)))
+	(optional log_rw_container_optional
+		(allow process logfile (dir (ioctl read write create getattr setattr lock add_name search open)))
+		(allow process logfile (file (ioctl read write create getattr setattr lock append open)))
+		(allow process logfile (lnk_file (ioctl read write getattr lock append open)))
+		(allow process var_t (dir (getattr search open)))
+		(allow process auditd_log_t (dir (ioctl read getattr lock search open)))
+		(allow process auditd_log_t (file (ioctl read getattr lock open)))
+	)
 )
 
 (block log_manage_container
-    (blockinherit log_rw_container)
+	(blockinherit log_rw_container)
 
-    (allow process logfile (dir (ioctl read write create getattr setattr lock unlink link rename add_name remove_name reparent search rmdir open)))
-    (allow process logfile (file (ioctl read write create getattr setattr lock append unlink link rename open)))
-    (allow process logfile (lnk_file (ioctl read write create getattr setattr lock append unlink link rename)))
-    (allow process auditd_log_t (dir (ioctl read write getattr lock search open)))
-    (allow process auditd_log_t (file (ioctl read write getattr lock open)))
+	(optional log_manage_container_optional
+		(allow process logfile (dir (ioctl read write create getattr setattr lock unlink link rename add_name remove_name reparent search rmdir open)))
+		(allow process logfile (file (ioctl read write create getattr setattr lock append unlink link rename open)))
+		(allow process logfile (lnk_file (ioctl read write create getattr setattr lock append unlink link rename)))
+		(allow process auditd_log_t (dir (ioctl read write getattr lock search open)))
+		(allow process auditd_log_t (file (ioctl read write getattr lock open)))
+	)
 )

--- a/udica/templates/net_container.cil
+++ b/udica/templates/net_container.cil
@@ -1,25 +1,25 @@
 (block net_container
-	(blockinherit container)
-	(typeattributeset sandbox_net_domain (process))
+	(optional net_container_optional
+		(typeattributeset sandbox_net_domain (process))
+	)
 )
 
 (block restricted_net_container
-    (blockinherit container)
+	(optional restricted_net_container_optional
+		(allow process process (tcp_socket (ioctl read getattr lock write setattr append bind connect getopt setopt shutdown create listen accept)))
+		(allow process process (udp_socket (ioctl read getattr lock write setattr append bind connect getopt setopt shutdown create)))
+		(allow process process (sctp_socket (ioctl read getattr lock write setattr append bind connect getopt setopt shutdown create)))
 
-    (allow process process (tcp_socket (ioctl read getattr lock write setattr append bind connect getopt setopt shutdown create listen accept)))
-    (allow process process (udp_socket (ioctl read getattr lock write setattr append bind connect getopt setopt shutdown create)))
-    (allow process process (sctp_socket (ioctl read getattr lock write setattr append bind connect getopt setopt shutdown create)))
+		(allow process proc_t (lnk_file (read)))
 
-    (allow process proc_t (lnk_file (read)))
+		(allow process node_t (node (tcp_recv tcp_send recvfrom sendto)))
+		(allow process node_t (node (udp_recv recvfrom)))
+		(allow process node_t (node (udp_send sendto)))
 
-    (allow process node_t (node (tcp_recv tcp_send recvfrom sendto)))
-    (allow process node_t (node (udp_recv recvfrom)))
-    (allow process node_t (node (udp_send sendto)))
+		(allow process node_t (udp_socket (node_bind)))
+		(allow process node_t (tcp_socket (node_bind)))
 
-    (allow process node_t (udp_socket (node_bind)))
-    (allow process node_t (tcp_socket (node_bind)))
-
-    (allow process http_port_t (tcp_socket (name_connect)))
-    (allow process http_port_t (tcp_socket (recv_msg send_msg)))
+		(allow process http_port_t (tcp_socket (name_connect)))
+		(allow process http_port_t (tcp_socket (recv_msg send_msg)))
+	)
 )
-

--- a/udica/templates/tmp_container.cil
+++ b/udica/templates/tmp_container.cil
@@ -1,15 +1,15 @@
 (block tmp_container
-    (blockinherit container)
-
-    (allow process tmpfile (dir (getattr search open)))
-    (allow process tmpfile (file (ioctl read getattr lock open)))
-
+	(optional tmp_container_optional
+		(allow process tmpfile (dir (getattr search open)))
+		(allow process tmpfile (file (ioctl read getattr lock open)))
+	)
 )
 
 (block tmp_rw_container
-    (blockinherit tmp_container)
+	(blockinherit tmp_container)
 
-    (allow process tmpfile (file (ioctl read write getattr lock append open)))
-    (allow process tmpfile (dir (ioctl read write getattr lock append open)))
-
+	(optional tmp_rw_container_optional
+		(allow process tmpfile (file (ioctl read write getattr lock append open)))
+		(allow process tmpfile (dir (ioctl read write getattr lock append open)))
+	)
 )

--- a/udica/templates/tty_container.cil
+++ b/udica/templates/tty_container.cil
@@ -1,10 +1,9 @@
 (block tty_container
-    (blockinherit container)
+	(optional tty_container_optional
+		(allow process device_t (dir (getattr search open)))
+		(allow process device_t (dir (ioctl read getattr lock search open)))
+		(allow process device_t (lnk_file (read getattr)))
 
-    (allow process device_t (dir (getattr search open)))
-    (allow process device_t (dir (ioctl read getattr lock search open)))
-    (allow process device_t (lnk_file (read getattr)))
-
-    (allow process devtty_t (chr_file (ioctl read write getattr lock append open)))
+		(allow process devtty_t (chr_file (ioctl read write getattr lock append open)))
+	)
 )
-

--- a/udica/templates/virt_container.cil
+++ b/udica/templates/virt_container.cil
@@ -1,16 +1,14 @@
 (block virt_container
-    (blockinherit container)
+	(optional virt_container_optional
+		(allow process var_t (dir (getattr search open)))
+		(allow process var_t (lnk_file (read getattr)))
 
-    (allow process var_t (dir (getattr search open)))
-    (allow process var_t (lnk_file (read getattr)))
+		(allow process var_run_t (dir (getattr search open)))
+		(allow process var_run_t (lnk_file (read getattr)))
 
-    (allow process var_run_t (dir (getattr search open)))
-    (allow process var_run_t (lnk_file (read getattr)))
+		(allow process virt_var_run_t (dir (getattr search open)))
+		(allow process virt_var_run_t (sock_file (write getattr append open)))
 
-    (allow process virt_var_run_t (dir (getattr search open)))
-    (allow process virt_var_run_t (sock_file (write getattr append open)))
-
-    (allow process virtd_t (unix_stream_socket (connectto)))
-
+		(allow process virtd_t (unix_stream_socket (connectto)))
+	)
 )
-

--- a/udica/templates/x_container.cil
+++ b/udica/templates/x_container.cil
@@ -1,27 +1,25 @@
 (block x_container
-    (blockinherit container)
+	(optional x_container_optional
+		(allow xserver_t process (shm (getattr read write associate unix_read unix_write lock)))
 
-    (allow xserver_t process (shm (getattr read write associate unix_read unix_write lock)))
+		(allow process xserver_t (unix_stream_socket (connectto)))
 
-    (allow process xserver_t (unix_stream_socket (connectto)))
+		(allow process device_t (dir (getattr search open)))
 
-    (allow process device_t (dir (getattr search open)))
+		(allow process dri_device_t (chr_file (ioctl read write getattr lock append open map)))
 
-    (allow process dri_device_t (chr_file (ioctl read write getattr lock append open map)))
+		(allow process xserver_misc_device_t (chr_file (ioctl read write getattr lock append open map)))
 
-    (allow process xserver_misc_device_t (chr_file (ioctl read write getattr lock append open map)))
+		(allow process urandom_device_t (chr_file (open read)))
 
-    (allow process urandom_device_t (chr_file (open read)))
+		(allow process tmpfs_t (dir (getattr search open)))
 
-    (allow process tmpfs_t (dir (getattr search open)))
+		(allow process tmp_t (dir (getattr search open)))
+		(allow process tmp_t (lnk_file (read getattr)))
 
-    (allow process tmp_t (dir (getattr search open)))
-    (allow process tmp_t (lnk_file (read getattr)))
+		(allow process xserver_tmp_t (dir (getattr search open)))
+		(allow process xserver_tmp_t (sock_file (write getattr append open)))
 
-    (allow process xserver_tmp_t (dir (getattr search open)))
-    (allow process xserver_tmp_t (sock_file (write getattr append open)))
-
-    (allow process xserver_exec_t (file (ioctl read getattr lock map execute execute_no_trans open)))
-
+		(allow process xserver_exec_t (file (ioctl read getattr lock map execute execute_no_trans open)))
+	)
 )
-


### PR DESCRIPTION
Cil parser was recently updated to reject the following:
(block template1 (type t) )
(block template2 (blockinherit template1))
(block b (blockinherit template1) (blockinherit template2))

Re-declaration of type t
Previous declaration of type at /var/lib/selinux/targeted/tmp/modules/400/test/cil:1
Failed to copy block contents into blockinherit
Failed to resolve AST
semodule:  Failed!

Remove (blockinherit container) from all templates so that "process" and
"socket" are only defined once (by inheriting "container" block in the
generated policy).
All allow rules referencing "process" and "socket" now need to be
enclosed in an optional block.

While at it, unify indentation.

Signed-off-by: Vit Mojzis <vmojzis@redhat.com>