### PR TITLE
Fix generating policy for Crio mounts

### DIFF
--- a/tests/selinux.py
+++ b/tests/selinux.py
@@ -25,6 +25,8 @@ def selabel_lookup(selabel, directory, rc):
         return (0, None)
     elif directory == "/dev/fb0":
         return (0, "system_u:object_r:framebuf_device_t:s0")
+    elif directory == "/etc/hosts":
+        return (0, "system_u:object_r:net_conf_t:s0")
     else:
         return (0, "system_u:object_r:var_spool_t:s0")
 
@@ -32,5 +34,7 @@ def selabel_lookup(selabel, directory, rc):
 def getfilecon(directory):
     if directory == "/tmp/test":
         return (0, "system_u:object_r:user_tmp_t:s0")
+    elif directory == "/etc/hosts":
+        return (0, "system_u:object_r:net_conf_t:s0")
     else:
         return (0, "system_u:object_r:var_spool_t:s0")

--- a/tests/test_basic.cri.cil
+++ b/tests/test_basic.cri.cil
@@ -250,4 +250,8 @@
     (allow process zoneminder_spool_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write ))) 
     (allow process zoneminder_spool_t ( fifo_file ( getattr read write append ioctl lock open ))) 
     (allow process zoneminder_spool_t ( sock_file ( append getattr open read write ))) 
+    (allow process net_conf_t ( dir ( getattr ioctl lock open read search ))) 
+    (allow process net_conf_t ( file ( getattr ioctl lock open read ))) 
+    (allow process net_conf_t ( fifo_file ( getattr open read lock ioctl ))) 
+    (allow process net_conf_t ( sock_file ( getattr open read ))) 
 )

--- a/tests/test_basic.cri.json
+++ b/tests/test_basic.cri.json
@@ -46,9 +46,9 @@
       },
       {
         "containerPath": "/etc/hosts",
-        "hostPath": "/var/lib/kubelet/pods/59ecb6eb-de09-11e9-8ebe-02e4204e049a/etc-hosts",
+        "hostPath": "/etc/hosts",
         "propagation": "PROPAGATION_PRIVATE",
-        "readonly": false,
+        "readonly": true,
         "selinuxRelabel": false
       },
       {

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -119,7 +119,7 @@ class TestBase(unittest.TestCase):
         self.assert_policy(test_file("test_basic.docker.cil"))
 
     def test_basic_cri(self):
-        """Start CRI-O mounting /var/spool with read/write perms and /home with readonly perms"""
+        """Start CRI-O mounting /var/spool with read/write perms and /home and /etc/hosts with readonly perms"""
         output = self.run_udica(
             [
                 "udica",
@@ -135,7 +135,7 @@ class TestBase(unittest.TestCase):
         self.assert_policy(test_file("test_basic.cri.cil"))
 
     def test_basic_specified_engine_cri(self):
-        """Start CRI-O mounting /var/spool with read/write perms and /home with readonly perms"""
+        """Start CRI-O mounting /var/spool with read/write perms and /home and /etc/hosts with readonly perms"""
         output = self.run_udica(
             [
                 "udica",

--- a/udica/policy.py
+++ b/udica/policy.py
@@ -284,7 +284,7 @@ def write_policy_for_crio_mounts(mounts, policy):
             + " ))) \n"
         )
 
-    for contexts in sorted(set(contexts_readonly)):
+    for context in sorted(set(contexts_readonly)):
         policy.write(
             "    (allow process "
             + context


### PR DESCRIPTION
Fix issue introduced by
Commit 7c7b9ad505ab6b7cd809d30f1699d4bb7323ce0a
"Avoid duplicate rules for accessing  mounts and devices" where policy rules for "read-only mounts" are not generated properly.

Adjust Crio basic test to incorporate a read only mount that is not covered by a special case ("/home" is handled by "home_container" and anything under "/var/lib/kubelet" is ignored).

Thanks https://github.com/arcardon (jamjcardona@sbcglobal.net) for spotting this in the code.