### PR TITLE
Add --kerberos-access option

### DIFF
--- a/tests/test_kerberosaccess.podman.cil
+++ b/tests/test_kerberosaccess.podman.cil
@@ -1,0 +1,6 @@
+(block my_container
+    (blockinherit container)
+    (blockinherit kerberos_container)
+    (allow process process ( capability ( audit_write chown dac_override fowner fsetid kill mknod net_bind_service net_raw setfcap setgid setpcap setuid sys_chroot ))) 
+
+)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -331,6 +331,20 @@ class TestBase(unittest.TestCase):
         self.assert_templates(output, ["base_container", "tty_container"])
         self.assert_policy(test_file("test_ttyaccess.podman.cil"))
 
+    def test_kerberosaccess_podman(self):
+        """podman run fedora"""
+        output = self.run_udica(
+            [
+                "udica",
+                "-j",
+                "tests/test_default.podman.json",
+                "--kerberos-access",
+                "my_container",
+            ]
+        )
+        self.assert_templates(output, ["base_container", "kerberos_container"])
+        self.assert_policy(test_file("test_kerberosaccess.podman.cil"))
+
     def test_append_more_rules_podman(self):
         """podman run fedora"""
         output = self.run_udica(

--- a/udica/__main__.py
+++ b/udica/__main__.py
@@ -185,6 +185,13 @@ def get_args():
             action="store_true",
         )
         parser.add_argument(
+            "--kerberos-access",
+            help="Allow container to use Kerberos authentication ",
+            required=False,
+            dest="KerberosAccess",
+            action="store_true",
+        )
+        parser.add_argument(
             "-s",
             "--stream-connect",
             help="Allow container to stream connect with given SELinux domain ",

--- a/udica/policy.py
+++ b/udica/policy.py
@@ -129,6 +129,10 @@ def create_policy(
         policy.write("    (blockinherit tty_container)\n")
         add_template("tty_container")
 
+    if opts["KerberosAccess"]:
+        policy.write("    (blockinherit kerberos_container)\n")
+        add_template("kerberos_container")
+
     if ports:
         policy.write("    (blockinherit restricted_net_container)\n")
         add_template("net_container")


### PR DESCRIPTION
The option adds a new block inheritance, hence udica needs to require the corresponding version of container-selinux.