### PR TITLE
Add TCP and Unix Socket permissions

### DIFF
--- a/udica/__main__.py
+++ b/udica/__main__.py
@@ -216,6 +216,21 @@ def get_args():
             default=None,
         )
         parser.add_argument(
+            "--tcp-connect",
+            type=str,
+            help="Comma-separated list of TCP ports to allow connections to, e.g. --tcp-connect 5432,636",
+            dest="TcpConnect",
+            required=False,
+            default=None,
+        )
+        parser.add_argument(
+            "--unix-connect",
+            help="Allow container to connect to UNIX domain sockets",
+            required=False,
+            dest="UnixConnect",
+            action="store_true",
+        )
+        parser.add_argument(
             "-d",
             "--ansible",
             help="Generate ansible playbook to deploy SELinux policy for containers ",
@@ -334,6 +349,10 @@ def main():
 
     container_caps = sorted(engine_helper.get_caps(container_inspect, opts))
 
+    tcp_ports = []
+    if opts["TcpConnect"]:
+        tcp_ports = [int(port) for port in opts["TcpConnect"].split(",")]
+
     try:
         create_policy(
             opts,
@@ -343,6 +362,8 @@ def main():
             container_ports,
             append_rules,
             engine_helper.container_engine,
+            tcp_ports,
+            opts["UnixConnect"],
         )
     except Exception as e:
         print("Couldn't create policy:", e)

--- a/udica/policy.py
+++ b/udica/policy.py
@@ -106,7 +106,7 @@ def list_ports(port_number, port_proto):
 
 
 def create_policy(
-    opts, capabilities, devices, mounts, ports, append_rules, inspect_format
+    opts, capabilities, devices, mounts, ports, append_rules, inspect_format, tcp_ports, unix_connect
 ):
     policy = open(opts["ContainerName"] + ".cil", "w")
     policy.write("(block " + opts["ContainerName"] + "\n")
@@ -168,6 +168,20 @@ def create_policy(
                 + perms.socket[item["protocol"]]
                 + " (  name_bind ))) \n"
             )
+    
+    # TCP connect permissions
+    for port in tcp_ports:
+        policy.write(
+            "    (allow process "
+            + list_ports(port, "tcp")
+            + " ( tcp_socket ( name_connect ))) \n"
+        )
+
+    # UNIX socket connect permissions
+    if unix_connect:
+        policy.write(
+            "    (allow process container_runtime_t ( unix_stream_socket ( connectto ))) \n"
+        )
 
     # devices
     # Not applicable for CRI-O container engine


### PR DESCRIPTION
Hi,

This PR fixes issue #130.
This [blog](https://pradiptabanerjee.medium.com/case-study-in-security-hardening-of-a-red-hat-openshift-operator-6f509df97bc8) also raises the same caveat when using Udica with the `kata-monitor` daemonset in Kata Containers, stating that:

> While udica can create a good baseline policy from the container.json file, sometimes it might not be sufficient, and you will need customisations.
[...] 
The kata-monitor daemonset required permissions to listen on a TCP socket and connect to a Unix socket. We had to redo the policy generation and enable network access.

I've added support for specifying additional TCP and UNIX socket permissions.

- Implemented the ``--tcp-connect`` option to specify additional TCP port permissions.
- Implemented the ``--unix-connect`` option to allow UNIX domain socket connect permissions.
- Modified policy generation logic to include these additional permissions in the generated policy file.

To easily test the changes:
``` shell
# Add TCP and UNIX socket permissions to 'tests/test_basic.podman.json'
$ sudo udica -j test_basic.podman.json --tcp-connect 5432,636 --unix-connect test-container

# Verify that the new policies are added
$ cat test-container.cil | grep -E "(allow process (container_runtime_t|postgresql_port_t|ldap_port_t) \( (unix_stream_socket|tcp_socket) \( (connectto|name_connect) \)\))"
```

Thank you!
Fabien