### PR TITLE
github: disable testing on centos8

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,8 +20,6 @@ jobs:
           - quay.io/fedora/fedora:rawhide
           # test on the latest stable release of Fedora
           - quay.io/fedora/fedora:latest
-          # test on the stable release of Centos stream 8
-          - quay.io/centos/centos:stream8
           # test on the latest stable release of Centos stream
           - quay.io/centos/centos:stream9
     container:


### PR DESCRIPTION
Centos8 container always fails with
   Curl error (6): Couldn't resolve host name for
   mirrorlist.centos.org